### PR TITLE
Fix exclude rules for file import

### DIFF
--- a/Promptor/FileAggregator.swift
+++ b/Promptor/FileAggregator.swift
@@ -157,6 +157,10 @@ class FileAggregator: ObservableObject {
     
     // Recursively create a file tree
     private func createFileTree(at url: URL, relativeTo rootURL: URL, fileManager fm: FileManager) -> FileNode? {
+        // ✱ NEW ✱ — consult user settings before doing any expensive work
+        if url != rootURL && !settings.shouldImport(url) {
+            return nil           // excluded by suffix, folder name or size
+        }
         do {
             // Get required attributes
             let resourceKeys: [URLResourceKey] = [.isDirectoryKey, .nameKey, .fileSizeKey]


### PR DESCRIPTION
Users can now reliably hide unwanted files/folders from the import tree, keeping the sidebar and generated prompts clean and focused on relevant text files.

This PR addresses an issue where the importer was ignoring the user’s exclude rules (e.g. ignored folders, file suffixes, and max file size). The root cause was that createFileTree(at:relativeTo:fileManager:) never consulted settings.shouldImport(_:), so everything was always added to the tree regardless of exclusions.

The guard skips any file or directory (except the root) that shouldImport deems excluded.
Now the importer respects:
- ignoreFolders (entire directory trees)
- ignoreSuffixes (file extensions)
- maxFileSize (over-sized binaries)